### PR TITLE
fix: PDF export width consistency and page break handling

### DIFF
--- a/packages/cli/src/export/__tests__/pdf.test.ts
+++ b/packages/cli/src/export/__tests__/pdf.test.ts
@@ -21,6 +21,7 @@ const mockPage = {
   waitForSelector: vi.fn(),
   waitForFunction: vi.fn().mockResolvedValue(undefined),
   waitForTimeout: vi.fn(),
+  evaluate: vi.fn().mockResolvedValue(undefined),
   pdf: vi.fn(() => Buffer.from('%PDF-mock')),
 };
 
@@ -81,6 +82,7 @@ describe('exportPDF', () => {
       clientBundle: '/* hydrate bundle */',
       ir,
       themeVars: undefined,
+      maxWidth: '64rem',
     });
   });
 
@@ -89,7 +91,7 @@ describe('exportPDF', () => {
     await exportPDF(ir);
 
     expect(buildHtmlTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'From Metadata' }),
+      expect.objectContaining({ title: 'From Metadata', maxWidth: '64rem' }),
     );
   });
 
@@ -97,7 +99,7 @@ describe('exportPDF', () => {
     await exportPDF(createTestIR());
 
     expect(buildHtmlTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'GlyphJS Export' }),
+      expect.objectContaining({ title: 'GlyphJS Export', maxWidth: '64rem' }),
     );
   });
 
@@ -110,11 +112,11 @@ describe('exportPDF', () => {
     });
   });
 
-  it('defaults viewport width to 800', async () => {
+  it('defaults viewport width to 1024', async () => {
     await exportPDF(createTestIR());
 
     expect(mockPage.setViewportSize).toHaveBeenCalledWith({
-      width: 800,
+      width: 1024,
       height: 1024,
     });
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,7 +53,7 @@ program
   .option('-o, --output <path>', 'write to file instead of stdout')
   .option('-t, --theme <theme>', 'theme to use: light or dark', 'light')
   .option('--theme-file <path>', 'YAML file with custom theme variables')
-  .option('-w, --width <px>', 'document width in pixels', '800')
+  .option('-w, --width <px>', 'document width in pixels', '1024')
   .option('--title <title>', 'override document title')
   .option('--page-size <size>', 'PDF page size (e.g. Letter, A4)', 'Letter')
   .option('--margin <margin>', 'PDF margin in CSS shorthand (e.g. "1in", "0.5in 1in")', '1in')

--- a/packages/cli/src/rendering/__tests__/html-template.test.ts
+++ b/packages/cli/src/rendering/__tests__/html-template.test.ts
@@ -152,10 +152,30 @@ describe('buildHtmlTemplate', () => {
     expect(html).toContain('#glyph-root a');
   });
 
-  it('sets max-width on #glyph-root', () => {
+  it('sets max-width on #glyph-root to default 52rem', () => {
     const html = buildHtmlTemplate({ body: '' });
 
     expect(html).toContain('max-width: 52rem');
+  });
+
+  it('uses custom maxWidth when provided', () => {
+    const html = buildHtmlTemplate({ body: '', maxWidth: '64rem' });
+
+    expect(html).toContain('max-width: 64rem');
+    expect(html).not.toContain('max-width: 52rem');
+  });
+
+  // ── @media print CSS ─────────────────────────────────────
+
+  it('includes @media print rules for page breaks', () => {
+    const html = buildHtmlTemplate({ body: '' });
+
+    expect(html).toContain('@media print');
+    expect(html).toContain('break-inside: avoid');
+    expect(html).toContain('page-break-inside: avoid');
+    expect(html).toContain('break-after: avoid');
+    expect(html).toContain('orphans: 3');
+    expect(html).toContain('widows: 3');
   });
 
   // ── Custom themeVars ───────────────────────────────────────

--- a/packages/cli/src/rendering/__tests__/screenshot.test.ts
+++ b/packages/cli/src/rendering/__tests__/screenshot.test.ts
@@ -84,6 +84,7 @@ describe('captureBlockScreenshot', () => {
         blocks: [block],
       }),
       themeVars: undefined,
+      maxWidth: '64rem',
     });
   });
 
@@ -169,7 +170,7 @@ describe('captureBlockScreenshot', () => {
 
     expect(renderBlockToHTML).toHaveBeenCalledWith(expect.anything(), 'dark', undefined);
     expect(buildHtmlTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ theme: 'dark', themeVars: undefined }),
+      expect.objectContaining({ theme: 'dark', themeVars: undefined, maxWidth: '64rem' }),
     );
   });
 
@@ -194,7 +195,7 @@ describe('captureBlockScreenshot', () => {
 
     expect(renderBlockToHTML).toHaveBeenCalledWith(expect.anything(), 'light', customVars);
     expect(buildHtmlTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ themeVars: customVars }),
+      expect.objectContaining({ themeVars: customVars, maxWidth: '64rem' }),
     );
   });
 

--- a/packages/cli/src/rendering/html-template.ts
+++ b/packages/cli/src/rendering/html-template.ts
@@ -15,6 +15,8 @@ export interface HtmlTemplateOptions {
   ir?: GlyphIR;
   /** Optional pre-resolved theme CSS variables. When provided, overrides the built-in theme lookup. */
   themeVars?: Record<string, string>;
+  /** Max width for the root container. Defaults to '52rem'. */
+  maxWidth?: string;
 }
 
 /**
@@ -22,7 +24,15 @@ export interface HtmlTemplateOptions {
  * with theme CSS variables injected as inline styles on the root container.
  */
 export function buildHtmlTemplate(options: HtmlTemplateOptions): string {
-  const { body, theme = 'light', title = 'GlyphJS Render', clientBundle, ir, themeVars } = options;
+  const {
+    body,
+    theme = 'light',
+    title = 'GlyphJS Render',
+    clientBundle,
+    ir,
+    themeVars,
+    maxWidth = '52rem',
+  } = options;
 
   const vars = themeVars ?? (theme === 'dark' ? DARK_THEME_VARS : LIGHT_THEME_VARS);
   const cssVars = themeVarsToCSS(vars);
@@ -63,7 +73,7 @@ export function buildHtmlTemplate(options: HtmlTemplateOptions): string {
 
     /* ── Prose styling ─────────────────────────────────── */
     #glyph-root {
-      max-width: 52rem;
+      max-width: ${maxWidth};
       margin: 0 auto;
       padding: 2rem 1.5rem;
       line-height: 1.7;
@@ -168,6 +178,26 @@ export function buildHtmlTemplate(options: HtmlTemplateOptions): string {
     }
     #glyph-root th {
       font-weight: 600;
+    }
+
+    @media print {
+      /* Keep component blocks together on one page */
+      [data-glyph-block] {
+        break-inside: avoid;
+        page-break-inside: avoid;
+      }
+
+      /* Don't orphan headings at the bottom of a page */
+      h1, h2, h3, h4, h5, h6 {
+        break-after: avoid;
+        page-break-after: avoid;
+      }
+
+      /* Minimum lines before/after page breaks */
+      p {
+        orphans: 3;
+        widows: 3;
+      }
     }
   </style>
 </head>

--- a/packages/cli/src/rendering/screenshot.ts
+++ b/packages/cli/src/rendering/screenshot.ts
@@ -79,6 +79,7 @@ export async function captureBlockScreenshot(
     clientBundle,
     ir: singleBlockIR,
     themeVars,
+    maxWidth: '64rem',
   });
 
   // Stage 2: Load the HTML and wait for network idle


### PR DESCRIPTION
## Summary
- Fixed KPI components rendering as 3+1 in PDF export instead of 4-across by widening the default viewport from 800px to 1024px, setting `maxWidth: '64rem'` on the HTML template, and updating the CLI `--width` default
- Added DOM freeze before `page.pdf()` to prevent `ResizeObserver`/React re-renders at the narrower print paper width — resolves `auto-fill` grid formulas to explicit `repeat(N, 1fr)` track counts and snapshots the DOM as static HTML
- Added `@media print` CSS for page break handling: `break-inside: avoid` on component blocks, `break-after: avoid` on headings, and `orphans/widows` on paragraphs

## Test plan
- [x] All 223 CLI unit tests pass
- [x] Full monorepo typecheck passes (16 packages)
- [x] Full monorepo lint passes (9 packages)
- [x] Visual verification: PDF export of demo.md shows KPI as 4-across, matching serve output
- [x] Pre-existing parser golden file CRLF failures on Windows confirmed on main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)